### PR TITLE
一些重构

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       matrix:
         os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
-        rust: [ "stable" ]
-    continue-on-error: ${{ matrix.rust != 'stable' }}
+        rust: [ "nightly" ]
+    continue-on-error: ${{ matrix.rust != 'nightly' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -55,8 +55,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           # Not MSRV because its harder to jump between versions and people are
-          # more likely to have stable
-          toolchain: stable
+          # more likely to have nightly
+          toolchain: nightly
           profile: minimal
           override: true
           components: rustfmt

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -63,22 +63,22 @@ jobs:
         include:
           - build: linux
             os: ubuntu-latest
-            rust: stable
+            rust: nightly
             target: x86_64-unknown-linux-musl
             file: observer_ward_amd64
           - build: macos
             os: macos-latest
-            rust: stable
+            rust: nightly
             target: x86_64-apple-darwin
             file: observer_ward_darwin
           - build: macos_m1
             os: macos-latest
-            rust: stable
+            rust: nightly
             target: aarch64-apple-darwin
             file: observer_ward_aarch64_darwin
           - build: win-msvc
             os: windows-latest
-            rust: stable
+            rust: nightly
             target: i686-pc-windows-msvc
             file: observer_ward.exe
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
  "ahash",
  "bytes 1.1.0",
  "bytestring",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cookie 0.16.0",
  "derive_more",
  "encoding_rs",
@@ -228,7 +228,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
  "opaque-debug",
@@ -338,7 +338,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -538,12 +538,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -656,7 +650,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -665,7 +659,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -787,7 +781,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
  "redox_users 0.3.5",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -805,7 +799,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -817,7 +811,7 @@ checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users 0.4.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -828,7 +822,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users 0.4.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -855,7 +849,7 @@ version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -898,7 +892,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -934,22 +928,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -1063,7 +1041,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1074,7 +1052,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.10.3+wasi-snapshot-preview1",
 ]
@@ -1232,16 +1210,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1278,16 +1247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -1347,7 +1306,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1391,34 +1350,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1429,45 +1369,10 @@ checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
+ "miow",
  "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio 0.6.23",
- "miow 0.3.7",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1476,7 +1381,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1498,23 +1403,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1585,7 +1479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1647,12 +1541,12 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall 0.2.10",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1871,7 +1765,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1965,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2079,7 +1973,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -2099,7 +1993,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -2116,7 +2010,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -2155,7 +2049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2245,12 +2139,12 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall 0.2.10",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2261,7 +2155,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2272,7 +2166,7 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2327,7 +2221,7 @@ dependencies = [
  "stdweb",
  "time-macros 0.1.1",
  "version_check",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2393,21 +2287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.23",
- "mio-named-pipes",
- "mio-uds",
- "num_cpus",
  "pin-project-lite 0.1.12",
- "signal-hook-registry",
- "slab",
- "tokio-macros 0.2.6",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2425,19 +2305,8 @@ dependencies = [
  "parking_lot",
  "pin-project-lite 0.2.8",
  "signal-hook-registry",
- "tokio-macros 1.7.0",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
@@ -2534,7 +2403,7 @@ version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "pin-project-lite 0.2.8",
  "tracing-core",
@@ -2656,7 +2525,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -2681,7 +2550,7 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -2763,12 +2632,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -2776,12 +2639,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2795,7 +2652,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2810,7 +2667,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2820,16 +2677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
  "toml",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,6 @@ dependencies = [
  "dirs 4.0.0",
  "env_logger",
  "futures 0.3.21",
- "lazy_static",
  "log",
  "openssl",
  "prettytable-rs",
@@ -2732,7 +2731,6 @@ name = "what_server"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.21",
- "lazy_static",
  "regex",
  "serde",
  "serde_derive",
@@ -2751,7 +2749,6 @@ dependencies = [
  "cached",
  "encoding_rs",
  "futures 0.3.21",
- "lazy_static",
  "md-5",
  "mime",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ lto = true
 opt-level = "z"
 codegen-units = 1
 panic = "abort"
+strip = true
 
 [dependencies]
 clap = { default-features = false, version = "3.1.7", features = ["std"] }
@@ -34,7 +35,6 @@ reqwest = { version = "0.11.10", features = ["socks", "blocking", "gzip"] }
 term = "*"
 observer_ward_what_web = { path = "what_web", package = "what_web" }
 observer_ward_what_server = { path = "what_server", package = "what_server" }
-lazy_static = "1.4.0"
 zip = "0.6.0"
 openssl = { version = "0.10", features = ["vendored"] }
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { default-features = false, version = "3.1.7", features = ["std"] }
 url = { version = "2.1.1", features = ["serde"] }
 csv = "1.1.6"
 dirs = "4.0.0"
-tokio = { version = "1.16.1", features = ["full"] }
+tokio = { version = "1.14.0", default-features = false }
 prettytable-rs = "^0.8"
 textwrap = "0.15"
 log = "0.4.16"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ```bash
 git clone https://github.com/0x727/ObserverWard
 cd ObserverWard
-cargo build --target  x86_64-unknown-linux-musl --release --all-features
+cargo build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-musl --release --all-features
 ```
 
 - 更多安装细节请查看当前项目的Actions自动化编译构建流程[文件](https://github.com/0x727/ObserverWard/blob/main/.github/workflows/basic.yml)。

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,13 +1,13 @@
 #[cfg(not(target_os = "windows"))]
 extern crate daemonize;
 
+use crate::error::Error;
 use crate::{print_color, Helper, ObserverWard, ObserverWardConfig, OBSERVER_WARD_PATH};
 use actix_web::web::Data;
 use actix_web::{get, middleware, post, web, App, HttpResponse, HttpServer, Responder};
 use actix_web_httpauth::extractors::bearer::{BearerAuth, Config};
 #[cfg(not(target_os = "windows"))]
 use daemonize::Daemonize;
-use openssl::error::ErrorStack;
 use openssl::ssl::{SslAcceptor, SslAcceptorBuilder, SslFiletype, SslMethod};
 use std::collections::{HashMap, HashSet};
 #[cfg(not(target_os = "windows"))]
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::thread;
 use tokio::sync::RwLock;
 
-fn get_ssl_config() -> Result<SslAcceptorBuilder, ErrorStack> {
+fn get_ssl_config() -> Result<SslAcceptorBuilder, Error> {
     let mut builder = SslAcceptor::mozilla_intermediate(SslMethod::tls())?;
     let key_path = OBSERVER_WARD_PATH.join("key.pem");
     let cert_path = OBSERVER_WARD_PATH.join("cert.pem");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+#[derive(Debug)]
+pub enum Error {
+    IoError(std::io::Error),
+    OpensslError(openssl::error::ErrorStack),
+    ZipError(zip::result::ZipError),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::IoError(e)
+    }
+}
+
+impl From<openssl::error::ErrorStack> for Error {
+    fn from(e: openssl::error::ErrorStack) -> Self {
+        Error::OpensslError(e)
+    }
+}
+
+impl From<zip::result::ZipError> for Error {
+    fn from(e: zip::result::ZipError) -> Self {
+        Error::ZipError(e)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::IoError(e) => write!(f, "Io error: {}", e),
+            Error::OpensslError(e) => write!(f, "Openssl error: {}", e),
+            Error::ZipError(e) => write!(f, "Zip error: {}", e),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
+#![feature(once_cell)]
+
 use crate::cli::ObserverWardConfig;
+use error::Error;
 use futures::channel::mpsc::unbounded;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use lazy_static::lazy_static;
 use observer_ward_what_server::{NmapFingerPrint, WhatServer};
 use observer_ward_what_web::fingerprint::WebFingerPrint;
 use observer_ward_what_web::{RequestOption, TemplateResult, WhatWeb, WhatWebResult};
@@ -17,6 +19,7 @@ use std::io;
 use std::io::Cursor;
 use std::io::{BufRead, Read};
 use std::iter::FromIterator;
+use std::lazy::SyncLazy;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use term::color::Color;
@@ -24,6 +27,7 @@ use tokio::process::Command;
 
 pub mod api;
 pub mod cli;
+pub mod error;
 
 use serde::{Deserialize, Serialize};
 
@@ -133,22 +137,22 @@ pub struct Helper {
     config: ObserverWardConfig,
     msg: HashMap<String, String>,
 }
-lazy_static! {
-    static ref OBSERVER_WARD_PATH: PathBuf = {
-        let mut config_path = PathBuf::new();
-        if let Some(cp) = dirs::config_dir() {
-            config_path = cp;
-        } else {
-            println!("Cannot create config directory{:?}", config_path);
-            std::process::exit(0);
-        }
-        let observer_ward = config_path.join("observer_ward");
-        if !observer_ward.is_dir() || !observer_ward.exists() {
-            std::fs::create_dir_all(&observer_ward).unwrap_or_default();
-        }
-        observer_ward
-    };
-}
+
+static OBSERVER_WARD_PATH: SyncLazy<PathBuf> = SyncLazy::new(|| -> PathBuf {
+    let mut config_path = PathBuf::new();
+    if let Some(cp) = dirs::config_dir() {
+        config_path = cp;
+    } else {
+        println!("Cannot create config directory{:?}", config_path);
+        std::process::exit(0);
+    }
+    let observer_ward = config_path.join("observer_ward");
+    if !observer_ward.is_dir() || !observer_ward.exists() {
+        std::fs::create_dir_all(&observer_ward).unwrap_or_default();
+    }
+    observer_ward
+});
+
 impl Helper {
     pub fn new(config: &ObserverWardConfig) -> Self {
         let ro = RequestOption::new(&config.timeout, &config.proxy);
@@ -252,7 +256,7 @@ impl Helper {
 
     pub fn read_web_fingerprint(&mut self, verify: &str) -> Vec<WebFingerPrint> {
         if !verify.is_empty() {
-            if let Ok(mut file) = File::open(verify.to_string()) {
+            if let Ok(mut file) = File::open(verify) {
                 let mut data = String::new();
                 file.read_to_string(&mut data).ok();
                 let mut web_fingerprint: Vec<WebFingerPrint> = vec![];
@@ -439,7 +443,7 @@ pub fn print_results_and_save(
     }
 }
 
-fn extract_plugins_zip(f_name: &Path, extract_target_path: &Path) -> Result<(), std::io::Error> {
+fn extract_plugins_zip(f_name: &Path, extract_target_path: &Path) -> Result<(), Error> {
     let plugins_path = extract_target_path.join("plugins");
     if plugins_path.exists() {
         std::fs::remove_dir_all(plugins_path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,7 +489,7 @@ pub async fn get_plugins_by_nuclei(w: WhatWebResult, config: &ObserverWardConfig
     if let Ok(template_output) = String::from_utf8(output.stdout) {
         let templates_output: Vec<String> = template_output
             .split_terminator('\n')
-            .map(|s| s.to_string())
+            .map(String::from)
             .collect();
         for line in templates_output.iter() {
             let template: TemplateResult = serde_json::from_str(line).unwrap_or_default();
@@ -676,9 +676,9 @@ impl ObserverWard {
 
 // 去重
 pub fn strings_to_urls(domains: String) -> HashSet<String> {
-    let target_list: Vec<String> = domains
+    let target_list = domains
         .split_terminator('\n')
-        .map(|s| s.to_string())
-        .collect();
+        .map(String::from)
+        .collect::<Vec<_>>();
     HashSet::from_iter(target_list)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,21 @@ use std::io::{self, Read};
 
 use observer_ward::api::run_server;
 use observer_ward::cli::ObserverWardConfig;
+use observer_ward::error::Error;
 use observer_ward::{
     print_opening, print_results_and_save, read_file_to_target, strings_to_urls, Helper,
     ObserverWard,
 };
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() {
+    match start().await {
+        Ok(_) => {}
+        Err(e) => println!("{}", e),
+    }
+}
+
+async fn start() -> Result<(), Error> {
     let config = ObserverWardConfig::new();
     if !config.stdin {
         print_opening();

--- a/what_server/Cargo.toml
+++ b/what_server/Cargo.toml
@@ -11,7 +11,6 @@ serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 serde_derive = "1.0"
-lazy_static = "1.4.0"
 regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"] }
 tokio = { version = "0.2", features = ["full"] }
 observer_ward_what_web = { path = "../what_web", package = "what_web" }

--- a/what_server/Cargo.toml
+++ b/what_server/Cargo.toml
@@ -11,6 +11,9 @@ serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 serde_derive = "1.0"
-regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"] }
-tokio = { version = "0.2", features = ["full"] }
+regex = { version = "1.5.4", default-features = false, features = [
+    "std",
+    "unicode",
+] }
+tokio = { version = "0.2", default-features = false }
 observer_ward_what_web = { path = "../what_web", package = "what_web" }

--- a/what_server/src/lib.rs
+++ b/what_server/src/lib.rs
@@ -1,11 +1,11 @@
-#[macro_use]
-extern crate lazy_static;
+#![feature(once_cell)]
 
 use std::collections::HashSet;
 use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::io::{BufRead, Write};
+use std::lazy::SyncLazy;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -189,8 +189,9 @@ impl WhatServer {
     }
 }
 
-lazy_static! {
-    static ref NMAP_FINGERPRINT_LIB_DATA: Vec<NmapFingerPrint> = {
+#[allow(dead_code)]
+static NMAP_FINGERPRINT_LIB_DATA: SyncLazy<Vec<NmapFingerPrint>> =
+    SyncLazy::new(|| -> Vec<NmapFingerPrint> {
         let self_path: PathBuf = env::current_exe().unwrap_or_default();
         let path = Path::new(&self_path)
             .parent()
@@ -206,5 +207,4 @@ lazy_static! {
         file.read_to_string(&mut data).ok();
         let nmap_fingerprint: Vec<NmapFingerPrint> = serde_json::from_str(&data).expect("BAD JSON");
         nmap_fingerprint
-    };
-}
+    });

--- a/what_web/Cargo.toml
+++ b/what_web/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 
 [dependencies]
 encoding_rs = "0.8.28"
-regex = { version = "1.4.5", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.4.5", default-features = false, features = [
+    "std",
+    "unicode",
+] }
 mime = "0.3.16"
 md-5 = "0.9.1"
 base64 = "0.13.0"
@@ -17,7 +20,17 @@ serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
 openssl = { version = "0.10", features = ["vendored"] }
-reqwest = { version = "0.11.6", features = ["native-tls", "socks", "blocking", "gzip", "cookies", "json"] }
+reqwest = { version = "0.11.6", features = [
+    "native-tls",
+    "socks",
+    "blocking",
+    "gzip",
+    "cookies",
+    "json",
+] }
 futures = { version = "0.3", features = ["compat"] }
 url = { version = "2.1.1", features = ["serde"] }
-tokio = { version = "1.14.0", features = ["full"] }
+tokio = { version = "1.14.0", default-features = false, features = [
+    "process",
+    "macros",
+] }

--- a/what_web/Cargo.toml
+++ b/what_web/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4.0"
 encoding_rs = "0.8.28"
 regex = { version = "1.4.5", default-features = false, features = ["std", "unicode"] }
 mime = "0.3.16"

--- a/what_web/src/lib.rs
+++ b/what_web/src/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate lazy_static;
+#![feature(once_cell)]
 
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;

--- a/what_web/src/lib.rs
+++ b/what_web/src/lib.rs
@@ -188,10 +188,7 @@ where
         where
             E: de::Error,
         {
-            let name: Vec<String> = value
-                .split_terminator('\n')
-                .map(|s| s.to_string())
-                .collect();
+            let name: Vec<String> = value.split_terminator('\n').map(String::from).collect();
             Ok(HashSet::from_iter(name))
         }
         fn visit_seq<S>(self, visitor: S) -> Result<Self::Value, S::Error>


### PR DESCRIPTION
惰性求值不要使用lazy_static,改为使用内置的nightly feature once_cell 或者 once_cell create (lazy_static两年没更新了,once_cell已经进入std)。

统一错误处理，更方便也更直观，修复潜在的错误，zip error 和 io error 应该分别处理，不应该全部归于 io eror。

不要在main中返回dyn,这会导致不必要的二进制开销。

删除不必要的类型转换。

切换到nightly重新编译std,这可以带来微小的性能提升并且减少一些二进制开销。

 `Cargo.toml` 添加strip参数，在1.60+版本已经可以使用。

手动指定tokio features,不要full,不使用没用的功能,这样减少了一点开销并且可以加快一点编译速度。

格式化Cargo.toml。

ci改为nightly（大概。

x64 linux musl二进制文件减少到了6.8mb并获得了一些性能提升。

![Screenshot_20220418_173713](https://user-images.githubusercontent.com/36557882/163789515-b455394c-7a00-4b02-afdf-5b2b727e2d04.png)
